### PR TITLE
22-failed-commits-remove-all-local-changes

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -28,7 +28,8 @@ jobs:
       - name: Cache
         uses: actions/cache@v4
         with:
-          key: ${{ runner.os }}-build-${{ github.head_ref || github.ref_name }}
+          key: |
+            ${{ runner.os }}-build-${{ github.head_ref || github.ref_name }}
           restore-keys: |
             ${{ runner.os }}-build-main
           path: |

--- a/.github/workflows/trigger-release.yml
+++ b/.github/workflows/trigger-release.yml
@@ -38,7 +38,8 @@ jobs:
       - name: Cache
         uses: actions/cache@v4
         with:
-          key: ${{ runner.os }}-build-${{ github.head_ref || github.ref_name }}
+          key: |
+            ${{ runner.os }}-build-${{ github.head_ref || github.ref_name }}
           restore-keys: |
             ${{ runner.os }}-build-main
           path: |

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Main](https://github.com/simonhauck/gradle-release-plugin/actions/workflows/on-main-push.yml/badge.svg)](https://github.com/simonhauck/gradle-release-plugin/actions/workflows/on-main-push.yml)
 [![Plugin Portal](https://img.shields.io/maven-metadata/v/https/plugins.gradle.org/m2/io/github/simonhauck/release/io.github.simonhauck.release.gradle.plugin/maven-metadata.xml?label=Gradle%20Plugin%20Portal&colorB=brightgreen&logo=gradle)](https://plugins.gradle.org/plugin/io.github.simonhauck.release)
 
+
 <!-- TOC -->
 
 * [Gradle Release Plugin](#gradle-release-plugin)

--- a/release-plugin/src/main/kotlin/io/github/simonhauck/release/git/api/GitCommandResult.kt
+++ b/release-plugin/src/main/kotlin/io/github/simonhauck/release/git/api/GitCommandResult.kt
@@ -21,6 +21,8 @@ data class GitStatusResult(
     val untracked: List<String>
 ) {
     fun allEmpty() = staged.isEmpty() && unstaged.isEmpty() && untracked.isEmpty()
+
+    fun notEmpty() = !allEmpty()
 }
 
 fun Either<GitError, *>.isOk(): Boolean = isRight()

--- a/release-plugin/src/main/kotlin/io/github/simonhauck/release/git/internal/process/ProcessResult.kt
+++ b/release-plugin/src/main/kotlin/io/github/simonhauck/release/git/internal/process/ProcessResult.kt
@@ -1,8 +1,11 @@
 package io.github.simonhauck.release.git.internal.process
 
 import arrow.core.Either
+import arrow.core.getOrElse
 
 internal typealias ProcessResult = Either<ProcessError, ProcessSuccess>
+
+internal fun ProcessResult.exitCode(): Int? = map { it.exitCode }.getOrElse { it.exitCode }
 
 internal data class ProcessSuccess(val exitCode: Int, val output: List<String>)
 

--- a/release-plugin/src/test/kotlin/io/github/simonhauck/release/tasks/CommitAndTagTaskTest.kt
+++ b/release-plugin/src/test/kotlin/io/github/simonhauck/release/tasks/CommitAndTagTaskTest.kt
@@ -103,11 +103,6 @@ class CommitAndTagTaskTest {
     @Test
     fun `git tag should fail and revert the previous commands when the tag is already set`() =
         testDriver(tmpDir) {
-            createValidRepositoryWithRemote()
-            client1Api.tag("v1.0.0", "Initial tag").assertIsOk()
-
-            File(client1WorkDir, "newFile.txt").writeText("Hello World")
-
             appendContentToBuildGradle(
                 """
                 |tasks.register<CommitAndTagTask>("commitAndTag") {
@@ -118,8 +113,11 @@ class CommitAndTagTaskTest {
             """
                     .trimMargin()
             )
+            createValidRepositoryWithRemote()
+            client1Api.tag("v1.0.0", "Initial tag").assertIsOk()
+            File(client1WorkDir, "newFile.txt").writeText("Hello World")
 
-            val runner = testKitRunner().withArguments("commitAndTag").buildAndFail()
+            val runner = testKitRunner().withArguments("commitAndTag", "--info").buildAndFail()
 
             val actual = runner.task(":commitAndTag")?.outcome
 


### PR DESCRIPTION
#22 when the git operation fails, revert only the files related to the commit