### PR TITLE
#27 add support for property files that have other unrelated properties

### DIFF
--- a/release-plugin/src/main/kotlin/io/github/simonhauck/release/file/internal/PropertiesFileUtil.kt
+++ b/release-plugin/src/main/kotlin/io/github/simonhauck/release/file/internal/PropertiesFileUtil.kt
@@ -2,21 +2,104 @@ package io.github.simonhauck.release.file.internal
 
 import java.io.File
 import java.util.*
+import java.util.regex.Pattern
+import org.gradle.api.logging.Logging
 
 internal class PropertiesFileUtil {
+    private val log = Logging.getLogger(PropertiesFileUtil::class.java)
 
     fun readProperties(file: File): Map<String, String> {
-        val apply = Properties().apply { file.inputStream().use { load(it) } }
-        return apply.map { it.key.toString() to it.value.toString() }.toMap()
+        val lines = file.readLinesIfExists()
+
+        return lines.fold(emptyMap()) { acc, line ->
+            val propertyFromLine = line.parseProperty().toMap()
+            acc + propertyFromLine
+        }
     }
 
-    fun writePropertiesFile(file: File, values: Map<String, String>) {
+    fun updatePropertiesFile(file: File, propertiesToUpdateOrAdd: Map<String, String>) {
+        val existingProperties = readProperties(file)
+
+        val propertiesToAdd = propertiesToUpdateOrAdd.minus(existingProperties.keys)
+
+        file.appendProperties(propertiesToAdd)
+
+        file.updateProperties(propertiesToUpdateOrAdd)
+    }
+
+    private fun File.updateProperties(propertiesToUpdateOrAdd: Map<String, String>) {
+        val lines =
+            readLinesIfExists().joinToString(System.lineSeparator()) {
+                updatePropertyLine(it, propertiesToUpdateOrAdd)
+            }
+        writeText(lines)
+    }
+
+    private fun updatePropertyLine(
+        line: String,
+        propertiesToUpdateOrAdd: Map<String, String>
+    ): String {
+        val property = line.parseProperty() ?: return line
+        val newValue = propertiesToUpdateOrAdd[property.first] ?: return line
+        val separator = detectSeparatorForProperties(line) ?: return line
+
+        return "${property.first}$separator$newValue"
+    }
+
+    private fun File.appendProperties(propertiesToBeAdded: Map<String, String>) {
+        val propertySeparator = detectPropertiesSeparatorInFileContent(this)
+
         val content =
-            values
-                .map { (key, value) -> "$key=$value" }
+            propertiesToBeAdded
+                .map { (key, value) -> "$key$propertySeparator$value" }
                 .sorted()
                 .joinToString(System.lineSeparator())
 
-        file.writeText(content)
+        if (shouldAddLineSeparatorAtStart(this)) {
+            appendText(System.lineSeparator())
+        }
+
+        appendText(content)
+    }
+
+    fun detectSeparatorForProperties(line: String): String? {
+        val matcher = Pattern.compile("\\s*[:=]\\s*").matcher(line)
+
+        val separator = if (matcher.find()) matcher.group() else null
+
+        return separator
+    }
+
+    private fun detectPropertiesSeparatorInFileContent(file: File): String {
+        val lines = file.readLinesIfExists()
+
+        return lines.firstNotNullOfOrNull { detectSeparatorForProperties(it) } ?: DEFAULT_SEPARATOR
+    }
+
+    private fun shouldAddLineSeparatorAtStart(file: File): Boolean {
+        return file.exists() && file.readLines().last().isNotEmpty()
+    }
+
+    private fun String.parseProperty(): Pair<String, String>? {
+        return byteInputStream().use { inputStream ->
+            val properties = Properties()
+            properties.load(inputStream)
+            properties.map { it.key.toString() to it.value.toString() }.firstOrNull()
+        }
+    }
+
+    private fun File.readLinesIfExists(): List<String> {
+        if (!exists()) {
+            log.debug("File ${this.absolutePath} does not exist. Returning empty file content")
+            return emptyList()
+        }
+        return readLines()
+    }
+
+    private fun Pair<String, String>?.toMap(): Map<String, String> =
+        if (this == null) emptyMap() else mapOf(this)
+
+    companion object {
+        private const val DEFAULT_SEPARATOR = "="
     }
 }

--- a/release-plugin/src/main/kotlin/io/github/simonhauck/release/version/internal/VersionHolder.kt
+++ b/release-plugin/src/main/kotlin/io/github/simonhauck/release/version/internal/VersionHolder.kt
@@ -33,13 +33,8 @@ internal class VersionHolder(private val tmpFileLocation: File) : VersionHolderA
     }
 
     override fun writeVersionPropertyToFile(file: File, version: Version) {
-        val updatedMap =
-            readPropertiesFile(file).toMutableMap().apply {
-                put("version", version.value)
-                toMap()
-            }
-
-        PropertiesFileUtil().writePropertiesFile(file, updatedMap)
+        val propertiesToUpdateOrAdd = mapOf("version" to version.value)
+        PropertiesFileUtil().updatePropertiesFile(file, propertiesToUpdateOrAdd)
     }
 
     private fun Properties.writeToFile(file: File) {

--- a/release-plugin/src/test/kotlin/io/github/simonhauck/release/file/internal/PropertiesFileUtilTest.kt
+++ b/release-plugin/src/test/kotlin/io/github/simonhauck/release/file/internal/PropertiesFileUtilTest.kt
@@ -48,14 +48,13 @@ class PropertiesFileUtilTest {
 
         PropertiesFileUtil().updatePropertiesFile(file, properties)
 
-        val actual = file.readText()
+        val actual = file.readLines()
 
         val expected =
-            """
-            |someOtherProperty=anotherValue
-            |someProperty=value
-            """
-                .trimMargin()
+            listOf(
+                "someOtherProperty=anotherValue",
+                "someProperty=value",
+            )
         assertThat(actual).isEqualTo(expected)
     }
 
@@ -80,16 +79,15 @@ class PropertiesFileUtilTest {
 
         PropertiesFileUtil().updatePropertiesFile(file, properties)
 
-        val actual = file.readText()
+        val actual = file.readLines()
 
         val expected =
-            """
-            |someProperty=somePropertyNewValue
-            |# Some comment
-            |someOtherProperty=anotherValue
-            |newProperty=newValue
-            """
-                .trimMargin()
+            listOf(
+                "someProperty=somePropertyNewValue",
+                "# Some comment",
+                "someOtherProperty=anotherValue",
+                "newProperty=newValue",
+            )
         assertThat(actual).isEqualTo(expected)
     }
 
@@ -110,15 +108,14 @@ class PropertiesFileUtilTest {
 
         PropertiesFileUtil().updatePropertiesFile(file, properties)
 
-        val actual = file.readText()
+        val actual = file.readLines()
 
         val expected =
-            """
-            |someProperty: somePropertyNewValue
-            |someOtherProperty: anotherValue
-            |newProperty: newValue
-            """
-                .trimMargin()
+            listOf(
+                "someProperty: somePropertyNewValue",
+                "someOtherProperty: anotherValue",
+                "newProperty: newValue",
+            )
         assertThat(actual).isEqualTo(expected)
     }
 
@@ -137,14 +134,13 @@ class PropertiesFileUtilTest {
 
         PropertiesFileUtil().updatePropertiesFile(file, properties)
 
-        val actual = file.readText()
+        val actual = file.readLines()
 
         val expected =
-            """
-            |someProperty=value
-            |newProperty=newValue
-            """
-                .trimMargin()
+            listOf(
+                "someProperty=value",
+                "newProperty=newValue",
+            )
         assertThat(actual).isEqualTo(expected)
     }
 

--- a/release-plugin/src/test/kotlin/io/github/simonhauck/release/file/internal/PropertiesFileUtilTest.kt
+++ b/release-plugin/src/test/kotlin/io/github/simonhauck/release/file/internal/PropertiesFileUtilTest.kt
@@ -1,0 +1,182 @@
+package io.github.simonhauck.release.file.internal
+
+import java.io.File
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestFactory
+import org.junit.jupiter.api.io.TempDir
+
+class PropertiesFileUtilTest {
+
+    @TempDir lateinit var tempDir: File
+
+    @Test
+    fun `should read valid properties from the file`() {
+        val file =
+            tempDir.resolve("test.properties").apply {
+                writeText(
+                    """
+                    |someProperty=value
+                    |
+                    |someOtherProperty=anotherValue
+                    |propertyWithOtherSeparator: dot
+                    |    whiteSpace: yes
+                    |
+                    |#comment=this should be filtered
+                    """
+                        .trimMargin())
+            }
+
+        val actual = PropertiesFileUtil().readProperties(file)
+
+        val expected =
+            mapOf(
+                "someProperty" to "value",
+                "someOtherProperty" to "anotherValue",
+                "propertyWithOtherSeparator" to "dot",
+                "whiteSpace" to "yes",
+            )
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `should create the property file and write the properties if not existing`() {
+        val file = tempDir.resolve("test.properties")
+
+        val properties = mapOf("someProperty" to "value", "someOtherProperty" to "anotherValue")
+
+        PropertiesFileUtil().updatePropertiesFile(file, properties)
+
+        val actual = file.readText()
+
+        val expected =
+            """
+            |someOtherProperty=anotherValue
+            |someProperty=value
+            """
+                .trimMargin()
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `should add missing and update existing properties without deleting comments or unrelated properties`() {
+        val file =
+            tempDir.resolve("test.properties").apply {
+                writeText(
+                    """
+                    |someProperty=value
+                    |# Some comment
+                    |someOtherProperty=anotherValue
+                    """
+                        .trimMargin())
+            }
+
+        val properties =
+            mapOf(
+                "newProperty" to "newValue",
+                "someProperty" to "somePropertyNewValue",
+            )
+
+        PropertiesFileUtil().updatePropertiesFile(file, properties)
+
+        val actual = file.readText()
+
+        val expected =
+            """
+            |someProperty=somePropertyNewValue
+            |# Some comment
+            |someOtherProperty=anotherValue
+            |newProperty=newValue
+            """
+                .trimMargin()
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `updating a properties file should use the pre-existing property separator`() {
+        val file =
+            tempDir.resolve("test.properties").apply {
+                writeText(
+                    """
+                    |someProperty: value
+                    |someOtherProperty: anotherValue
+                    """
+                        .trimMargin())
+            }
+
+        val properties =
+            mapOf("someProperty" to "somePropertyNewValue", "newProperty" to "newValue")
+
+        PropertiesFileUtil().updatePropertiesFile(file, properties)
+
+        val actual = file.readText()
+
+        val expected =
+            """
+            |someProperty: somePropertyNewValue
+            |someOtherProperty: anotherValue
+            |newProperty: newValue
+            """
+                .trimMargin()
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `should add a line separator at the start of the file if it is missing`() {
+        val file =
+            tempDir.resolve("test.properties").apply {
+                writeText(
+                    """
+                    |someProperty=value
+                    """
+                        .trimMargin())
+            }
+
+        val properties = mapOf("newProperty" to "newValue")
+
+        PropertiesFileUtil().updatePropertiesFile(file, properties)
+
+        val actual = file.readText()
+
+        val expected =
+            """
+            |someProperty=value
+            |newProperty=newValue
+            """
+                .trimMargin()
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @TestFactory
+    fun shouldDetectPropertiesSeparatorTests(): List<DynamicTest> =
+        listOf(
+                "someProperty = value" to " = ",
+                "someProperty=value" to "=",
+                "someProperty= value" to "= ",
+                "  someProperty = value" to " = ",
+                "someProperty:value" to ":",
+                "someProperty : value" to " : ",
+                "someProperty: value" to ": ",
+                "  someProperty : value" to " : ",
+            )
+            .map {
+                DynamicTest.dynamicTest(
+                    "shouldDetectPropertiesSeparator() should map ${it.first} to ${it.second}") {
+                        shouldDetectPropertiesSeparator(it.first, it.second)
+                    }
+            }
+
+    @Test
+    fun `should return null if no separator can be detected`() {
+        val actual = PropertiesFileUtil().detectSeparatorForProperties("")
+
+        assertThat(actual).isEqualTo(null)
+    }
+
+    private fun shouldDetectPropertiesSeparator(fileContent: String, expected: String) {
+        val actual = PropertiesFileUtil().detectSeparatorForProperties(fileContent)
+
+        assertThat(actual).isEqualTo(expected)
+    }
+}

--- a/release-plugin/src/test/kotlin/io/github/simonhauck/release/plugin/ReleasePluginTest.kt
+++ b/release-plugin/src/test/kotlin/io/github/simonhauck/release/plugin/ReleasePluginTest.kt
@@ -412,4 +412,32 @@ internal class ReleasePluginTest {
             assertThat(lastCommit.commiterEmail).isEqualTo("user1@mail.com")
         }
     }
+
+    @Test
+    fun `should support property files with colon as separator and other unrelated properties`() {
+        testDriver(tmpDir) {
+            createValidRepositoryWithRemote()
+
+            val versionFile =
+                client1WorkDir.resolve("version.properties").apply {
+                    writeText(
+                        """
+                    |# Some comment
+                    |unrelatedProperty: unrelatedValue
+                    |version: 1.0.0
+                    |someProperty: value
+                """
+                            .trimMargin())
+                }
+
+            testKitRunner().withArguments("release", "-PreleaseType=major").build()
+
+            assertThat(versionFile.readLines())
+                .containsExactly(
+                    "# Some comment",
+                    "unrelatedProperty: unrelatedValue",
+                    "version: 2.0.1-SNAPSHOT",
+                    "someProperty: value")
+        }
+    }
 }

--- a/release-plugin/src/test/kotlin/io/github/simonhauck/release/version/api/VersionHolderApiTest.kt
+++ b/release-plugin/src/test/kotlin/io/github/simonhauck/release/version/api/VersionHolderApiTest.kt
@@ -37,7 +37,7 @@ internal class VersionHolderApiTest {
         val versionHolderApi = createVersionHolder()
         val version = Version("1.0.0")
 
-        val file = File(tempDir, "version.properties").apply { createNewFile() }
+        val file = tempDir.resolve("version.properties")
 
         versionHolderApi.writeVersionPropertyToFile(file, version)
 
@@ -50,11 +50,7 @@ internal class VersionHolderApiTest {
     fun `should return the version from the properties file`() {
         val versionHolderApi = createVersionHolder()
 
-        val file =
-            File(tempDir, "version.properties").apply {
-                createNewFile()
-                writeText("version=1.0.0")
-            }
+        val file = File(tempDir, "version.properties").apply { writeText("version=1.0.0") }
 
         val actual = versionHolderApi.loadVersionFromFileOrThrow(file)
 
@@ -71,6 +67,36 @@ internal class VersionHolderApiTest {
         assertThatThrownBy { versionHolderApi.loadVersionFromFileOrThrow(file) }
             .isInstanceOf(GradleException::class.java)
             .hasMessage("No 'version' property found in $file")
+    }
+
+    @Test
+    fun `should leave unrelated properties and comments in the file untouched`() {
+        val versionHolderApi = createVersionHolder()
+
+        val file =
+            File(tempDir, "version.properties").apply {
+                val content =
+                    listOf(
+                            "firstProperty=something",
+                            "#This is a random comment",
+                            "version=1.0.0",
+                            "unrelated=property",
+                        )
+                        .joinToString(System.lineSeparator())
+                writeText(content)
+            }
+
+        versionHolderApi.writeVersionPropertyToFile(file, Version("1.0.1"))
+
+        val actual = file.readLines()
+
+        assertThat(actual)
+            .containsExactly(
+                "firstProperty=something",
+                "#This is a random comment",
+                "version=1.0.1",
+                "unrelated=property",
+            )
     }
 
     private fun createVersionHolder(): VersionHolderApi {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,7 +10,6 @@ plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
 }
 
-buildCache { local { removeUnusedEntriesAfterDays = 10 } }
 
 includeBuild("build-logic")
 


### PR DESCRIPTION
Rework property writer to just updated or append properties and leave unrelated properties or comments untouched