### PR TITLE
Add property to check for pre-release versions recursive in submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ release {
 
     // Check for snapshot / pre-release versions
     checkForPreReleaseVersions.set(true) // Enable/disable pre-release version checks
+    checkRecursiveForPreReleaseVersions.set(true) // Check submodules for pre-release versions
     ignorePreReleaseDependenciesFile.set(null) // File listing dependencies to ignore for pre-release checks in form of group:name
     ignorePreReleaseDependencies.set(emptyList()) // List of dependencies to ignore for pre-release checks in form of group:name
 

--- a/release-plugin/src/main/kotlin/io/github/simonhauck/release/plugin/ReleaseExtension.kt
+++ b/release-plugin/src/main/kotlin/io/github/simonhauck/release/plugin/ReleaseExtension.kt
@@ -19,6 +19,7 @@ abstract class ReleaseExtension(
 
     // Check for snapshot / pre-release versions
     val checkForPreReleaseVersions: Property<Boolean> = booleanProperty(true)
+    val checkRecursiveForPreReleaseVersions: Property<Boolean> = booleanProperty(true)
     val ignorePreReleaseDependenciesFile: RegularFileProperty = fileProperty()
     val ignorePreReleaseDependencies: ListProperty<String> = stringListProperty()
 

--- a/release-plugin/src/main/kotlin/io/github/simonhauck/release/util/ProjectVersionCollector.kt
+++ b/release-plugin/src/main/kotlin/io/github/simonhauck/release/util/ProjectVersionCollector.kt
@@ -1,0 +1,24 @@
+package io.github.simonhauck.release.util
+
+import org.gradle.api.Project
+import org.gradle.api.artifacts.Dependency
+
+internal class ProjectVersionCollector {
+
+    fun getProjectDependencies(project: Project): List<String> {
+        return project.configurations.flatMap { it.dependencies }.asStringList()
+    }
+
+    fun getProjectDependenciesRecursive(project: Project): List<String> {
+        val projectDependencies = getProjectDependencies(project)
+        val subProjectDependencies =
+            project.subprojects.flatMap { getProjectDependenciesRecursive(it) }
+
+        return projectDependencies + subProjectDependencies
+    }
+
+    private fun List<Dependency>.asStringList(): List<String> {
+        return filter { it.group != null && it.version != null }
+            .map { "${it.group}:${it.name}:${it.version}" }
+    }
+}

--- a/release-plugin/src/test/kotlin/io/github/simonhauck/release/testdriver/ReleasePluginTestDriver.kt
+++ b/release-plugin/src/test/kotlin/io/github/simonhauck/release/testdriver/ReleasePluginTestDriver.kt
@@ -95,6 +95,12 @@ internal class SemanticVersioningProjectBuilder(
         buildGradleFile.appendText(content)
     }
 
+    fun appendContentToSettingsGradle(content: String) {
+        val settingsGradlePath = Paths.get(client1WorkDir.absolutePath, "settings.gradle.kts")
+        val settingsGradleFile = settingsGradlePath.toFile()
+        settingsGradleFile.appendText(content)
+    }
+
     fun updateVersionProperties(version: String) {
         val versionPropertiesPath = Paths.get(client1WorkDir.absolutePath, "version.properties")
         val versionPropertiesFile = versionPropertiesPath.toFile()

--- a/release-plugin/src/test/resources/ssh-key/.gitattributes
+++ b/release-plugin/src/test/resources/ssh-key/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf


### PR DESCRIPTION
This PR introduces a new extension property to check for pre-release versions in submodules.

This is relevant for multi-module projects, where a project can contain submodules contain their own dependency list